### PR TITLE
Multithread fix (#2)

### DIFF
--- a/sensors_plugin.c
+++ b/sensors_plugin.c
@@ -248,9 +248,7 @@ SCOREP_Metric_Plugin_MetricProperties * scorep_plugin_libsensors_get_event_info(
 static void scorep_plugin_libsensors_fini()
 {
   counter_enabled=0;
-  if ( thread != 0 ) {
-    pthread_join(thread, NULL);
-  }
+  pthread_join(thread, NULL);
   sensors_cleanup();
 }
 


### PR DESCRIPTION
Fixes #2.

Given there are no metrics to be recorded, no thread will be launched.
However, the final cleanup handler will still attempt to join a thread -- which then fails, as there is no thread.

This PR adds state tracking of the thread and only joins if a thread actually has been launched.